### PR TITLE
Add color-on-error option for prompt sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ Change the prompt character:
 zstyle ':prompt:za:sign' char '>'
 ```
 
+Show the sign in red when the last command exits with a non-zero status:
+
+```zsh
+zstyle ':prompt:za:sign' color-on-error true
+```
+
 ### Git Integration
 
 The theme includes git-prompt.sh for displaying git repository information.
@@ -240,6 +246,7 @@ zstyle ':prompt:za:git' show-upstream true
 | `:prompt:za:right` | `template` | string | `%exitcode% %path% %git%` | Right prompt template |
 | `:prompt:za:path` | `style` | string | `minimal` | Path display style |
 | `:prompt:za:sign` | `char` | string | `$` | Prompt sign character |
+| `:prompt:za:sign` | `color-on-error` | boolean | `false` | Show sign in red on non-zero exit |
 | `:prompt:za:git` | `format` | string | ` (%s)` | Git info format string |
 | `:prompt:za:git` | `show-dirty` | boolean | `false` | Show dirty state |
 | `:prompt:za:git` | `show-untracked` | boolean | `false` | Show untracked files |

--- a/za-prompt.zsh-theme
+++ b/za-prompt.zsh-theme
@@ -158,6 +158,7 @@ __vim_mode() {
 __prompt_sign() {
     local sign="$(__prompt_zstyle "sign" "char" "$")"
     local vimode_enable="$(__prompt_zstyle_bool "vimode" "enable" "false")"
+    local color_on_error="$(__prompt_zstyle_bool "sign" "color-on-error" "false")"
 
     # Escape % character for prompt
     if [[ ${sign} == "%" ]]; then
@@ -171,12 +172,20 @@ __prompt_sign() {
             # In normal/visual/replace mode: use vim_mode_color
             echo "${vim_mode_color}${sign}${reset_prompt_color}"
         else
-            # In insert mode: show red on non-zero exit code
-            echo "%(?.${sign}.%F{red}${sign}%f)"
+            # In insert mode: show red on non-zero exit code if enabled
+            if [[ "${color_on_error}" == "true" ]]; then
+                echo "%(?.${sign}.%F{red}${sign}%f)"
+            else
+                echo "${sign}"
+            fi
         fi
     else
-        # vi mode disabled: show red on non-zero exit code
-        echo "%(?.${sign}.%F{red}${sign}%f)"
+        # vi mode disabled: show red on non-zero exit code if enabled
+        if [[ "${color_on_error}" == "true" ]]; then
+            echo "%(?.${sign}.%F{red}${sign}%f)"
+        else
+            echo "${sign}"
+        fi
     fi
 }
 

--- a/za-prompt.zsh-theme
+++ b/za-prompt.zsh-theme
@@ -159,10 +159,24 @@ __prompt_sign() {
     local sign="$(__prompt_zstyle "sign" "char" "$")"
     local vimode_enable="$(__prompt_zstyle_bool "vimode" "enable" "false")"
 
+    # Escape % character for prompt
+    if [[ ${sign} == "%" ]]; then
+        sign="%%"
+    fi
+
     if [[ "${vimode_enable}" == "true" ]]; then
-        echo "$(__vim_mode "${sign}")"
+        # vi mode enabled: use vim_mode_color, but show red on error if in insert mode
+        local reset_prompt_color="%f"
+        if [[ -n "${vim_mode_color}" ]]; then
+            # In normal/visual/replace mode: use vim_mode_color
+            echo "${vim_mode_color}${sign}${reset_prompt_color}"
+        else
+            # In insert mode: show red on non-zero exit code
+            echo "%(?.${sign}.%F{red}${sign}%f)"
+        fi
     else
-        echo "${sign}"
+        # vi mode disabled: show red on non-zero exit code
+        echo "%(?.${sign}.%F{red}${sign}%f)"
     fi
 }
 


### PR DESCRIPTION
## Overview

Add a new optional feature that changes the prompt sign color to red when the previous command exits with a non-zero status code.

<img width="155" height="87" alt="CleanShot 2025-12-14 at 02 09 01" src="https://github.com/user-attachments/assets/28e6f4bd-4428-44ed-86c9-d9078425bd2a" />


## Background

While the existing `%exitcode%` placeholder displays the exit code on error, users may want a more immediate visual indicator directly on the prompt sign. This allows users to quickly notice command failures without needing to check the right side of the prompt.

## Changes

- Add new zstyle option `color-on-error` under `:prompt:za:sign` context
- When enabled (`true`), the prompt sign turns red on non-zero exit codes
- Default is `false` to maintain backward compatibility
- Works with vi mode: in insert mode, error color takes precedence; in normal/visual/replace modes, vi mode colors are preserved
- Update README with usage documentation and configuration reference table
